### PR TITLE
Serialize/Deserialize layout. #6

### DIFF
--- a/components/Main.js
+++ b/components/Main.js
@@ -40,6 +40,9 @@ const query = gql`
       id
       title
       endDate
+      project {
+        id
+      }
       user {
         ...details
       }

--- a/components/task-diagram/index.js
+++ b/components/task-diagram/index.js
@@ -22,7 +22,8 @@ export default class TaskNode extends React.Component {
     super(props)
     this.state = {
       taskSelected: false,
-      taskSelectedData: {}
+      taskSelectedData: {},
+      taskPositions: {}
     }
 
     this.registerEngine()
@@ -36,6 +37,27 @@ export default class TaskNode extends React.Component {
     //
     this.nodePersistDate = NOP
     this.changeAssignee = NOP
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    // serialize the scene to localstorage to persist layout
+    //
+    const projectId = this.props.tasks[0].project.id
+    const serialized = JSON.stringify(this.model.serializeDiagram())
+    localStorage.setItem(`Project:${projectId}`, serialized)
+  }
+
+  componentDidMount() {
+    // Use saved layout for current project if it exists
+    //
+    const projectId = this.props.tasks[0].project.id
+    const data = localStorage.getItem(`Project:${projectId}`)
+    if (!data) return
+
+    const serialized = JSON.parse(data)
+    this.model = new DiagramModel()
+    this.model.deSerializeDiagram(serialized, this.engine)
+    this.engine.setDiagramModel(this.model)
   }
 
   registerEngine() {
@@ -130,7 +152,7 @@ export default class TaskNode extends React.Component {
      * Use a Promise in order to await the result from the deferred/timeout
      * function.
      */
-    const prettyPlease = new Promise(resolve => {
+    return new Promise(resolve => {
       setTimeout(() => {
         let parent = {}
         let child = {}
@@ -148,8 +170,6 @@ export default class TaskNode extends React.Component {
         return resolve({ childId: child.task.id, parentId: parent.task.id })
       }, 0)
     })
-
-    return prettyPlease
   }
 
   async switchToEdit(node, titleChanged, showTitle, title) {


### PR DESCRIPTION
The Tasks would render on top of each other in the top left
because positional data was not persisted.

This change uses react-diagram's engine's serialize/deserialize
on the componentDidMount and componentDidUpdate to get and set
layout snapshots to localStorage.

This implementation does not consider the case when a task is
added to the datastore but not reflected in local storage. This should
be reconciled for the next sprint